### PR TITLE
Increase grey item selling responsiveness

### DIFF
--- a/kSellGreyNRepair.lua
+++ b/kSellGreyNRepair.lua
@@ -29,6 +29,7 @@ local function OnEvent(self, event)
 				if itemRarity == 0 and itemSellPrice ~= 0 then
 					totalPrice = totalPrice + (itemSellPrice * itemCount)
 					UseContainerItem(myBags, bagSlots)
+					PickupMerchantItem()
 				end
 			end
 		end


### PR DESCRIPTION
This commit adds a call to the PickupMerchantItem() API function in order
to send items to the merchant one at a time while the selling loop is
running.

I added this since I noticed that it took a long time before my grey
items would disappear from my inventory. Sometimes they wouldn't disappear
until I closed and reopened my bags.

Signed-off-by: Jérémie Carpentier-Roy <jeremie.carpentier.roy@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kacpak/auto-sell-grey-and-repair-equipement/3)
<!-- Reviewable:end -->
